### PR TITLE
Add validation tests for correct records amount, existence, and order.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.loanpro</groupId>
     <artifactId>ACHLibrary</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.2.2-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>ACHLibrary</name>
     <description>ACHLibrary</description>

--- a/src/main/java/com/loanpro/achlibrary/dictionary/ACHRuleDictionary.java
+++ b/src/main/java/com/loanpro/achlibrary/dictionary/ACHRuleDictionary.java
@@ -13,6 +13,7 @@ import java.util.function.Consumer;
 import static com.loanpro.achlibrary.dictionary.ACHValidationTestSuite.isExpectedRecordLength;
 import static com.loanpro.achlibrary.dictionary.ACHValidationTestSuite.isExpectedDataType;
 import static com.loanpro.achlibrary.dictionary.ACHValidationTestSuite.isExpectedPageModulo;
+import static com.loanpro.achlibrary.dictionary.ACHValidationTestSuite.hasExpectedRecordsOrderAndPairQuantities;
 
 public class ACHRuleDictionary {
 
@@ -45,7 +46,8 @@ public class ACHRuleDictionary {
 					6, 11,
 					7, 11,
 					8, 11,
-					9, 8
+					9, 8,
+					10,1
 			);
 
 			for (Map.Entry<Integer, Integer> entry : recordFieldGuide.entrySet()) {
@@ -82,6 +84,7 @@ public class ACHRuleDictionary {
 
 		//TODO: Map other tests in ACHValidationTestSuite to each ACHRecordRule.
 		achPageRuleTests.put("isExpectedPageModulo", (achPage) -> isExpectedPageModulo(achPage));
+		achPageRuleTests.put("hasExpectedRecordsOrderAndPairQuantities", (achPage -> hasExpectedRecordsOrderAndPairQuantities(achPage)));
 
 		switch (achPageTypeNumber) {
 			case 1:
@@ -100,7 +103,6 @@ public class ACHRuleDictionary {
 		int expectedNumberOfFields;
 		int permittedPreviousRecordTypeNumber[];
 		int permittedNextRecordTypeNumber[];
-		boolean isPossiblePaddingLine = false;
 		boolean required = true;
 		int expectedNumberOfCharacters = 94;
 
@@ -114,47 +116,52 @@ public class ACHRuleDictionary {
 			case "11":
 				achRecordType = "file header";
 				expectedNumberOfFields = 13;
-				permittedPreviousRecordTypeNumber = new int[]{};
+				permittedPreviousRecordTypeNumber = new int[]{9,10};
 				permittedNextRecordTypeNumber = new int[]{5};
 				break;
 			case "15":
-				achRecordType = "file header";
+				achRecordType = "batch header";
 				expectedNumberOfFields = 13;
-				permittedPreviousRecordTypeNumber = new int[]{};
+				permittedPreviousRecordTypeNumber = new int[]{1,8};
 				permittedNextRecordTypeNumber = new int[]{6};
 				break;
 			case "16":
-				achRecordType = "file header";
+				achRecordType = "entry detail";
 				expectedNumberOfFields = 13;
-				permittedPreviousRecordTypeNumber = new int[]{};
+				permittedPreviousRecordTypeNumber = new int[]{5,6,7};
 				permittedNextRecordTypeNumber = new int[]{6, 7, 8};
 				break;
 			case "17":
-				achRecordType = "file header";
+				achRecordType = "entry detail addenda";
 				expectedNumberOfFields = 13;
-				permittedPreviousRecordTypeNumber = new int[]{};
+				permittedPreviousRecordTypeNumber = new int[]{6};
 				permittedNextRecordTypeNumber = new int[]{6, 8};
 				required = false;
 				break;
 			case "18":
-				achRecordType = "file header";
+				achRecordType = "batch control total";
 				expectedNumberOfFields = 13;
-				permittedPreviousRecordTypeNumber = new int[]{};
+				permittedPreviousRecordTypeNumber = new int[]{6,7};
 				permittedNextRecordTypeNumber = new int[]{5, 9};
 				break;
 			case "19":
-				//can also be a padding record
-				achRecordType = "file header";
+				achRecordType = "file control";
 				expectedNumberOfFields = 13;
-				permittedPreviousRecordTypeNumber = new int[]{};
-				permittedNextRecordTypeNumber = new int[]{9};
-				isPossiblePaddingLine = true;
+				permittedPreviousRecordTypeNumber = new int[]{8};
+				permittedNextRecordTypeNumber = new int[]{9,10};
+				break;
+			case "110":
+				//padding record
+				achRecordType = "padding";
+				expectedNumberOfFields = 1;
+				permittedPreviousRecordTypeNumber = new int[]{9};
+				permittedNextRecordTypeNumber = new int[]{10, 1};
 				break;
 			default:
 				throw new IllegalStateException("Unexpected value while creating an ACHRecordRule got: " + achPageTypeNumber.toString().concat(achRecordTypeNumber.toString()));
 		}
 
-		return ACHRecordRule.createNewInstance(achPageTypeNumber, achRecordTypeNumber, achRecordType, expectedNumberOfFields, permittedPreviousRecordTypeNumber, permittedNextRecordTypeNumber, isPossiblePaddingLine, required, expectedNumberOfCharacters, achFieldRules, achRecordRuleTests);
+		return ACHRecordRule.createNewInstance(achPageTypeNumber, achRecordTypeNumber, achRecordType, expectedNumberOfFields, permittedPreviousRecordTypeNumber, permittedNextRecordTypeNumber, required, expectedNumberOfCharacters, achFieldRules, achRecordRuleTests);
 	}
 
 	private static final ACHFieldRule mapFieldRule(Integer achPageTypeNumber, Integer achRecordTypeNumber, Integer achFieldRuleNumber) {
@@ -181,7 +188,7 @@ public class ACHRuleDictionary {
 			case "113":
 				achFieldLength = 10;
 				achFieldPosition = 4;
-				achDataTypeRule = ACHDataTypeRule.createNewInstance(DataType.OTHER, new String[]{"^ \\d+$"});
+				achDataTypeRule = ACHDataTypeRule.createNewInstance(DataType.OTHER, new String[]{"^ (?:[0-9])+$"});
 				break;
 			case "114":
 				achFieldLength = 10;
@@ -221,12 +228,12 @@ public class ACHRuleDictionary {
 			case "1111":
 				achFieldLength = 23;
 				achFieldPosition = 41;
-				achDataTypeRule = ACHDataTypeRule.createNewInstance(DataType.ASCII, new String[]{});
+				achDataTypeRule = ACHDataTypeRule.createNewInstance(DataType.ALPHA, new String[]{});
 				break;
 			case "1112":
 				achFieldLength = 23;
 				achFieldPosition = 64;
-				achDataTypeRule = ACHDataTypeRule.createNewInstance(DataType.ASCII, new String[]{});
+				achDataTypeRule = ACHDataTypeRule.createNewInstance(DataType.ALPHA, new String[]{});
 				break;
 			case "1113":
 				achFieldLength = 8;
@@ -246,7 +253,7 @@ public class ACHRuleDictionary {
 			case "153":
 				achFieldLength = 16;
 				achFieldPosition = 5;
-				achDataTypeRule = ACHDataTypeRule.createNewInstance(DataType.ASCII, new String[]{});
+				achDataTypeRule = ACHDataTypeRule.createNewInstance(DataType.ALPHA, new String[]{});
 				break;
 			case "154":
 				achFieldLength = 20;
@@ -336,12 +343,12 @@ public class ACHRuleDictionary {
 			case "168":
 				achFieldLength = 22;
 				achFieldPosition = 55;
-				achDataTypeRule = ACHDataTypeRule.createNewInstance(DataType.ASCII, new String[]{});
+				achDataTypeRule = ACHDataTypeRule.createNewInstance(DataType.ALPHA, new String[]{});
 				break;
 			case "169":
 				achFieldLength = 2;
 				achFieldPosition = 77;
-				achDataTypeRule = ACHDataTypeRule.createNewInstance(DataType.SPECIFICVALUES, new String[]{"R","S"});
+				achDataTypeRule = ACHDataTypeRule.createNewInstance(DataType.SPECIFICVALUES, new String[]{"R ","S "});
 				break;
 			case "1610":
 				achFieldLength = 1;
@@ -502,6 +509,11 @@ public class ACHRuleDictionary {
 				achFieldLength = 39;
 				achFieldPosition = 56;
 				achDataTypeRule = ACHDataTypeRule.createNewInstance(DataType.PADDING, new String[]{" "});
+				break;
+			case "1101":
+				achFieldLength = 94;
+				achFieldPosition = 1;
+				achDataTypeRule = ACHDataTypeRule.createNewInstance(DataType.PADDING, new String[]{"9"});
 				break;
 			default:
 				throw new IllegalStateException("Unexpected value while creating an ACHFieldRule got: " + achPageTypeNumber.toString().concat(achRecordTypeNumber.toString().concat(achFieldRuleNumber.toString())));

--- a/src/main/java/com/loanpro/achlibrary/dictionary/ACHValidationTestSuite.java
+++ b/src/main/java/com/loanpro/achlibrary/dictionary/ACHValidationTestSuite.java
@@ -6,36 +6,149 @@ import com.loanpro.achlibrary.model.ACHRecord;
 import com.loanpro.achlibrary.model.ACHValidationTest;
 import com.loanpro.achlibrary.rule.ACHDataTypeRule;
 
+import java.util.ArrayList;
+import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 public class ACHValidationTestSuite {
 
 	//Check if the pages record count is modulo of the expectedRecordCount. it returns a new ACHValidationTest with the results.
-	public static void isExpectedPageModulo(ACHPage achPage){
+	public static void isExpectedPageModulo(ACHPage achPage) {
 		String testName = "isExpectedPageModulo";
-		String message = "Page" + achPage.getAchPageNumber() + " record count is " + achPage.getAchRecords().size() +  " the expected count should be modulo " + achPage.getAchPageRule().getExpectedRecordModulo();
-		boolean isPass = achPage.getAchRecords().size() % achPage.getAchPageRule().getExpectedRecordModulo()  == 0 ? true : false;
+		String message = "Page" + achPage.getAchPageNumber() + " record count is " + achPage.getAchRecords().size() + " the expected count should be modulo " + achPage.getAchPageRule().getExpectedRecordModulo();
+		boolean isPass = achPage.getAchRecords().size() % achPage.getAchPageRule().getExpectedRecordModulo() == 0 ? true : false;
 
 		ACHValidationTest achValidationTest = new ACHValidationTest(achPage.getAchPageNumber(), achPage.getAchPageTypeNumber(), testName, message, isPass);
 		achPage.addToAchValidationTests(testName, achValidationTest);
 
 	}
 
-	public static void isExpectedRecordLength(ACHRecord achRecord){
+	private static ACHValidationTest isEqualAmountOfRecords(Integer achPageNumber, Integer achPageTypeNumber, int[] first, int[] second) {
+
+		String testName = first[0] + "And" + second[0] + "IsEqualAmountOfRecordsInPage";
+		String message = "Record " + first[0] + " and " + second[0] + " have an equal amount of occurrences.";
+		boolean isPass = true;
+
+
+		if (first[1] != second[1]) {
+			Map.of(
+					"less", first[0],
+					"less_val", first[1],
+					"greater", second[0],
+					"greater_val", second[1]);
+
+			isPass = false;
+			message = "There are " + first[1] + " records of type " + first[0] + " and " + second[1] + " records of type " + second[0] +
+					" these record types should have the same amount.";
+		}
+		return new ACHValidationTest(achPageNumber, achPageTypeNumber, testName, message, isPass);
+	}
+
+	public static void hasExpectedRecordsOrderAndPairQuantities(ACHPage achPage) {
+		ArrayList<ACHRecord> achRecords = achPage.getAchRecords();
+
+		Map<Integer, Integer> recordsInPage = Stream.of(new Integer[][]{
+				{1, 0},
+				{5, 0},
+				{6, 0},
+				{8, 0},
+				{9, 0}
+		}).collect(Collectors.toMap(data -> data[0], data -> data[1]));
+
+		int count = 0;
+		for (int i = 0; i < achRecords.size(); i++) {
+			ACHRecord achRecord = achRecords.get(i);
+			Integer achRecordTypeNumber = achRecord.getAchRecordTypeNumber();
+			int[] currentAchRecordsPermittedNextRecordTypes = achRecord.getAchRecordRule().getPermittedNextRecordTypeNumber();
+
+			if (achRecordTypeNumber != 7 && achRecordTypeNumber != 10) {
+				recordsInPage.put(achRecordTypeNumber, recordsInPage.get(achRecordTypeNumber) + 1);
+			}
+
+			if (i < achRecords.size() - 1) {
+				Integer nextAchRecordTypeNumber = achRecords.get(i + 1).getAchRecordTypeNumber();
+				Integer achRecordNumber = achRecords.get(i + 1).getAchRecordNumber();
+
+				count += 1;
+				if (!IntStream.of(currentAchRecordsPermittedNextRecordTypes).anyMatch(x -> x == nextAchRecordTypeNumber)) {
+					//TODO: Change the hashmap for a page/record/file to hold the tests into an array.. it doesn't
+					// make sense to be accessing the tests by name any time soon and hashmap may get overwritten tests
+					// if not careful in naming of the keys.
+					achPage.addToAchValidationTests(count + "record" + nextAchRecordTypeNumber +
+									"DoesNotProceedRecord" + achRecordTypeNumber,
+							new ACHValidationTest(achPage.getAchPageNumber(),
+									achPage.getAchPageTypeNumber(),
+									count + "record" + nextAchRecordTypeNumber +
+											"DoesNotProceedRecord" + achRecordTypeNumber,
+									"Record of type " + achRecordTypeNumber +
+											" on line " + achRecordNumber +
+											" can not be proceeded by record of type " + nextAchRecordTypeNumber,
+									false));
+				} else {
+					achPage.addToAchValidationTests(count + "record" + nextAchRecordTypeNumber +
+									"DoesProceedRecord" + achRecordTypeNumber,
+							new ACHValidationTest(achPage.getAchPageNumber(),
+									achPage.getAchPageTypeNumber(),
+									count + "record" + nextAchRecordTypeNumber +
+											"DoesProceedRecord" + achRecordTypeNumber,
+									"Record of type " + achRecordTypeNumber +
+											" on line " + achRecordNumber +
+											" is correctly proceeded by record of type " + nextAchRecordTypeNumber,
+									true));
+				}
+
+			}
+		}
+
+		for (Map.Entry<Integer, Integer> entry : recordsInPage.entrySet()) {
+			if (entry.getValue() < 1) {
+				achPage.addToAchValidationTests("requiredRecord" +
+								entry.getKey() + "IsEmpty",
+						new ACHValidationTest(achPage.getAchPageNumber(),
+								achPage.getAchPageTypeNumber(),
+								"requiredRecord" + entry.getKey() + "IsEmpty",
+								"Required record" + entry.getKey() + "is empty",
+								false));
+			} else {
+				achPage.addToAchValidationTests("requiredRecord" +
+								entry.getKey() + "Exists",
+						new ACHValidationTest(achPage.getAchPageNumber(),
+								achPage.getAchPageTypeNumber(),
+								"requiredRecord" + entry.getKey() + "Exists",
+								"Required record " + entry.getKey() + " exists;",
+								true));
+			}
+		}
+
+
+		ACHValidationTest oneNine = isEqualAmountOfRecords(achPage.getAchPageNumber(), achPage.getAchPageNumber(), new int[]{1, recordsInPage.get(1)}, new int[]{9, recordsInPage.get(9)});
+		achPage.addToAchValidationTests(oneNine.getTestName(), oneNine);
+
+		ACHValidationTest fiveEight = isEqualAmountOfRecords(achPage.getAchPageNumber(), achPage.getAchPageNumber(), new int[]{5, recordsInPage.get(5)}, new int[]{8, recordsInPage.get(8)});
+		achPage.addToAchValidationTests(fiveEight.getTestName(), fiveEight);
+	}
+
+
+	public static void isExpectedRecordLength(ACHRecord achRecord) {
 		String testName = "isExpectedRecordLength";
-		String message = "the record length is " + achRecord.getAchRawRecord().size() +  " the expected length is " + achRecord.getAchRecordRule().getExpectedNumberOfCharacters();
+		String message = "the record length is " + achRecord.getAchRawRecord().size() + " the expected length is " + achRecord.getAchRecordRule().getExpectedNumberOfCharacters();
 		boolean isPass = achRecord.getAchRawRecord().size() == achRecord.getAchRecordRule().getExpectedNumberOfCharacters() ? true : false;
 
 		ACHValidationTest achValidationTest = new ACHValidationTest(achRecord.getAchPageNumber(), achRecord.getAchPageTypeNumber(), achRecord.getAchRecordNumber(), achRecord.getAchRecordTypeNumber(), testName, message, isPass);
 		achRecord.addToAchValidationTests(testName, achValidationTest);
 	}
 
-	public static void isExpectedDataType(ACHField achField){
+	public static void isExpectedDataType(ACHField achField) {
 		ACHDataTypeRule achDataTypeRule = achField.getAchFieldRule().getAchFieldDataTypeRule();
-		String achArrayFieldToString = achField.getCurrentValue().stream()
-				.map(e->e.toString())
-				.collect(Collectors.joining());
+
+		StringBuilder sb = new StringBuilder();
+		for (Character ch : achField.getCurrentValue()) {
+			sb.append(ch);
+		}
+		String achArrayFieldToString = sb.toString();
 
 		String testName = "isExpectedDataType";
 		String message = "The expected data type is: " + achDataTypeRule.getDataType() +

--- a/src/main/java/com/loanpro/achlibrary/model/ACHPage.java
+++ b/src/main/java/com/loanpro/achlibrary/model/ACHPage.java
@@ -41,9 +41,9 @@ public class ACHPage {
 				if (charCountInRecord == 1) {
 					achRecordTypeNumber = ch;
 
-				} else if (ch == '\r'){
+				} else if (ch == '\r') {
 					continue;
-				}else if (ch == '\n' ) {
+				} else if (ch == '\n') {
 					this.createACHRecords(achPageNumber,
 							achPageTypeNumber,
 							achRecordNumber,
@@ -76,10 +76,14 @@ public class ACHPage {
 		}
 	}
 
-	private void createACHRecords(int achPageNumber, Character achPageTypeNumber, int achRecordNumber, Character achRecordTypeNumber, ArrayList<Character> achRawRecord){
+	private void createACHRecords(int achPageNumber, Character achPageTypeNumber, int achRecordNumber, Character achRecordTypeNumber, ArrayList<Character> achRawRecord) {
 //		TODO: Check character type and convert to correct type.
 		Integer pgTypNbr = Character.getNumericValue(achPageTypeNumber);
 		Integer rcdTypNbr = Character.getNumericValue(achRecordTypeNumber);
+
+		if (!achRawRecord.isEmpty() && achRawRecord.get(1) == '9' && achRawRecord.get(achRawRecord.size() - 1) == '9') {
+			rcdTypNbr = 10;
+		}
 
 		ACHRecord achRecord = new ACHRecord(
 				achPageNumber,

--- a/src/main/java/com/loanpro/achlibrary/rule/ACHDataTypeRule.java
+++ b/src/main/java/com/loanpro/achlibrary/rule/ACHDataTypeRule.java
@@ -30,7 +30,7 @@ public class ACHDataTypeRule {
 				justified = Justifications.LEFT;
 				paddingType = Paddings.SPACES;
 				letterCase = LetterCases.INSENSITIVE;
-				regex = "^[A-Za-z]+ *$";
+				regex = "^[A-Za-z ]+ *$";
 				break;
 			case NUMERIC:
 				justified = Justifications.RIGHT;
@@ -42,7 +42,7 @@ public class ACHDataTypeRule {
 				justified = Justifications.NONE;
 				paddingType = Paddings.NONE;
 				letterCase = LetterCases.INSENSITIVE;
-				regex = "^[0-9a-zA-Z]+ *$";
+				regex = "^[0-9a-zA-Z ]+ *$";
 				break;
 			case ASCII:
 				justified = Justifications.LEFT;

--- a/src/main/java/com/loanpro/achlibrary/rule/ACHRecordRule.java
+++ b/src/main/java/com/loanpro/achlibrary/rule/ACHRecordRule.java
@@ -14,21 +14,19 @@ public class ACHRecordRule {
 	private final int expectedNumberOfFields;
 	private final int permittedPreviousRecordTypeNumber[];
 	private final int permittedNextRecordTypeNumber[];
-	private final boolean isPossiblePaddingLine;
 	private final boolean required;
 	private final int expectedNumberOfCharacters;
 	private final HashMap<Integer, ACHFieldRule> achFieldRules;
 	//Stores the tests for this rule. It might source from a test suite so that different rules can reuse that test
 	private final Map<String, Consumer<ACHRecord>> achRecordRuleTests;
 
-	private ACHRecordRule(int achPageTypeNumber, int achRecordTypeNumber, String achRecordType, int expectedNumberOfFields, int[] permittedPreviousRecordTypeNumber, int[] permittedNextRecordTypeNumber, boolean isPossiblePaddingLine, boolean required, int expectedNumberOfCharacters, HashMap<Integer, ACHFieldRule> achFieldRules, Map<String, Consumer<ACHRecord>> achRecordRuleTests) {
+	private ACHRecordRule(int achPageTypeNumber, int achRecordTypeNumber, String achRecordType, int expectedNumberOfFields, int[] permittedPreviousRecordTypeNumber, int[] permittedNextRecordTypeNumber, boolean required, int expectedNumberOfCharacters, HashMap<Integer, ACHFieldRule> achFieldRules, Map<String, Consumer<ACHRecord>> achRecordRuleTests) {
 		this.achPageTypeNumber = achPageTypeNumber;
 		this.achRecordTypeNumber = achRecordTypeNumber;
 		this.achRecordType = achRecordType;
 		this.expectedNumberOfFields = expectedNumberOfFields;
 		this.permittedPreviousRecordTypeNumber = permittedPreviousRecordTypeNumber;
 		this.permittedNextRecordTypeNumber = permittedNextRecordTypeNumber;
-		this.isPossiblePaddingLine = isPossiblePaddingLine;
 		this.required = required;
 		this.expectedNumberOfCharacters = expectedNumberOfCharacters;
 		this.achFieldRules = achFieldRules;
@@ -41,7 +39,6 @@ public class ACHRecordRule {
 	                                              int expectedNumberOfFields,
 	                                              int[] permittedPreviousRecordTypeNumber,
 	                                              int[] permittedNextRecordTypeNumber,
-	                                              boolean isPossiblePaddingLine,
 	                                              boolean required,
 	                                              int expectedNumberOfCharacters,
 	                                              HashMap<Integer, ACHFieldRule> achFieldRules, HashMap<String, Consumer<ACHRecord>> achRecordRuleTests) {
@@ -52,7 +49,6 @@ public class ACHRecordRule {
 				expectedNumberOfFields,
 				permittedPreviousRecordTypeNumber,
 				permittedNextRecordTypeNumber,
-				isPossiblePaddingLine,
 				required,
 				expectedNumberOfCharacters,
 				achFieldRules, achRecordRuleTests);
@@ -80,10 +76,6 @@ public class ACHRecordRule {
 
 	public int[] getPermittedNextRecordTypeNumber() {
 		return permittedNextRecordTypeNumber;
-	}
-
-	public boolean isPossiblePaddingLine() {
-		return isPossiblePaddingLine;
 	}
 
 	public boolean isRequired() {


### PR DESCRIPTION
It seems that all the validations for the ACH files are working now. I am getting the correct errors when I should and none when I shouldn't. I have tested this with every file. Of course my unfamiliarity with ACH data and not having a subject expert review the tests with me doesn't help, but it is a work in progress and very extendible. I changed some of the ASCII field to ALPHA because I noticed that in no instance were any characters other than alphabetical characters used. It was quick and easy. This concludes the very basic version of the ACHLibrary. The frontend is still not complete since I was told by Mario that I do not need to focus on that.